### PR TITLE
Updating URL for eth-clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # slashing-protection-interchange-tests
 
-Light wrapper for https://github.com/eth2-clients/slashing-protection-interchange-tests
+Light wrapper for https://github.com/eth-clients/slashing-protection-interchange-tests


### PR DESCRIPTION
Was renamed from https://github.com/eth2-clients to https://github.com/eth-clients